### PR TITLE
Update sse4_crc32 to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">= 0.8.0"
   },
   "optionalDependencies": {
-    "sse4_crc32": "^2.0.0"
+    "sse4_crc32": "^3.0.0"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
This would help us out in [`gcloud-node`](https://github.com/GoogleCloudPlatform/gcloud-node) fix a hardware exception in `sse4_crc32` that is fixed in 3.0.0.

Related issues: 
- https://github.com/Voxer/sse4_crc32/issues/20
- https://github.com/GoogleCloudPlatform/gcloud-node/issues/425

Thanks! :smile: 