### PR TITLE
upgrade sse4_crc32 module

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">= 0.8.0"
   },
   "optionalDependencies": {
-    "sse4_crc32": "^2.1.2"
+    "sse4_crc32": "^4.1.2"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
This upgrades the sse4_crc32 module to the latest version (^4) which has support for Node v4.