### PR TITLE
Add Node.js feature checking

### DIFF
--- a/impls/js_crc32c.js
+++ b/impls/js_crc32c.js
@@ -71,9 +71,13 @@ var kCRCTable = new Int32Array([
   0xbe2da0a5, 0x4c4623a6, 0x5f16d052, 0xad7d5351
 ]);
 
+var hasBufferFrom = typeof Buffer.from === 'function'
+
 function calculate(buf, initial) {
   if (!Buffer.isBuffer(buf))
-    buf = new Buffer(buf);
+    // Check if the newer `Buffer.from` method introduced in Node.js v6 is
+    // available, otherwise fall back to deprecated Buffer constructor.
+    buf = hasBufferFrom ? Buffer.from(buf) : new Buffer(buf);
   var crc = (initial | 0) ^ -1;
   for (var i = 0; i < buf.length; i++)
     crc = kCRCTable[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);


### PR DESCRIPTION
Node.js v6 introduces the `Buffer.from` method, which should be used in favor of `new Buffer`. This PR addresses this issue by checking if the new method exists or not.
