### PR TITLE
added browser target for webpack, browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git://github.com/ashi009/node-fast-crc32c.git"
   },
   "main": "./loader",
+  "browser": "./impls/js_crc32c",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
The `browser` target in package.json is supported by [browserify](https://github.com/substack/node-browserify#browser-field)
 and [webpack](https://webpack.js.org/configuration/resolve/#resolve-mainfields)

The [buffer](https://github.com/feross/buffer) module is also used by both bundlers to provide a shim for the node `Buffer`.