### PR TITLE
load sse4_crc32c correctly in loader.js

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,10 +1,7 @@
-var fs = require('fs');
-
 module.exports = (function(loaders) {
 
 var impls = [
-  './impls/sse4_crc32c_hw',
-  './impls/sse4_crc32c_sw',
+  './impls/sse4_crc32c',
   './impls/js_crc32c'
 ];
 


### PR DESCRIPTION
This CL adds correct implementation to the loader list to make hardware accelerated CRC32 to be loaded.

In #15, `//impl/sse4_crc32c_hw.js` and `//impl/sse4_crc32c_sw.js` were removed, however, the loader script was not updated to reflect that. 
