### PR TITLE
update .{git,npm}ignore files and bump version to 1.0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
+.*
+*.log
+coverage
 node_modules
-npm-debug.log
-tmp
-coverage.html

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
-generate-tests.js
 benchmark
+coverage
+generate-tests.js
 test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fast-crc32c",
   "description": "CRC32C algorithm with hardware acceleration and software fallback.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Xiaoyi Shi <ashi009@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Due to #19, 1.0.6 was unpublished. This CL bumps version to 1.0.7 as the issue is resolved. Also, update .{git,npm}ignore files to avoid package unnecessary files during `npm publish`.

Updates #14 
Updates #19