### PR TITLE
Fix and optimization for non-x86 architectures

### DIFF
--- a/impls/rs_crc32c.js
+++ b/impls/rs_crc32c.js
@@ -1,0 +1,5 @@
+const {crc32c} = require('@node-rs/crc32');
+
+module.exports = {
+  calculate: crc32c,
+};

--- a/loader.js
+++ b/loader.js
@@ -1,6 +1,9 @@
 module.exports = (function() {
+  const os = require('os');
+  const isX86 = new Set(['ia32', 'x32', 'x64']).has(os.arch());
   const impls = [
-    './impls/sse4_crc32c',
+    ...(isX86 ? ['./impls/sse4_crc32c'] : []),
+    './impls/rs_crc32c',
     './impls/js_crc32c',
   ];
   for (const impl of impls) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "main": "./loader",
   "optionalDependencies": {
+    "@node-rs/crc32": "^1.1.0",
     "sse4_crc32": "^6.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Addresses #21. I wasn't sure based on that thread whether you'd prefer to remove `sse4_crc32` entirely, or if we're keeping it then whether it should be above or below `@node-rs/crc32`, but I'm happy to make any changes you'd like before merging.